### PR TITLE
Detect more Pi models

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,14 @@
 var fs = require('fs');
 var PI_MODEL_NO = [
+  // https://www.raspberrypi.org/documentation/hardware/raspberrypi/
   'BCM2708',
   'BCM2709',
   'BCM2710',
-  'BCM2835',
-  'BCM2837B0'
+  'BCM2835', // Raspberry Pi 1 and Zero
+  'BCM2836', // Raspberry Pi 2
+  'BCM2837', // Raspberry Pi 3 (and later Raspberry Pi 2)
+  'BCM2837B0', // Raspberry Pi 3B+ and 3A+
+  'BCM2711' // Raspberry Pi 4B
 ];
 
 function isPi (model) {


### PR DESCRIPTION
Added additional Raspberry Pi model numbers (Pi 2, 3, 4B), and commented which device each refers to. Source of the information also commented.